### PR TITLE
chore/quality-tooling

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/my-website/.husky/_/husky.sh
+++ b/my-website/.husky/_/husky.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+if [ -z "$husky_skip_init" ]; then
+  debug () {
+    [ "$HUSKY_DEBUG" = "1" ] && echo "husky:debug $1"
+  }
+
+  readonly hook_name="$(basename "$0")"
+  debug "starting $hook_name..."
+
+  if [ "$HUSKY" = "0" ]; then
+    debug "HUSKY env variable is set to 0, skipping hook"
+    exit 0
+  fi
+
+  readonly husky_skip_init=1
+  export husky_skip_init
+  sh -e "$0" "$@"
+  exitCode="$?"
+
+  if [ $exitCode != 0 ]; then
+    echo "husky - $hook_name hook exited with code $exitCode (error)"
+  fi
+
+  exit $exitCode
+fi

--- a/my-website/.husky/pre-commit
+++ b/my-website/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npx lint-staged

--- a/my-website/.prettierrc
+++ b/my-website/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "semi": true,
+  "singleQuote": true
+}

--- a/my-website/eslint.config.js
+++ b/my-website/eslint.config.js
@@ -1,0 +1,25 @@
+import react from 'eslint-plugin-react';
+
+export default [
+  {
+    files: ['**/*.{js,jsx}'],
+    languageOptions: {
+      ecmaVersion: 2021,
+      sourceType: 'module',
+      globals: {
+        browser: true,
+        node: true
+      }
+    },
+    plugins: { react },
+    rules: {
+      'no-unused-vars': 'warn',
+      'react/react-in-jsx-scope': 'off'
+    },
+    settings: {
+      react: {
+        version: 'detect'
+      }
+    }
+  }
+];

--- a/my-website/package.json
+++ b/my-website/package.json
@@ -32,7 +32,8 @@
     "format": "prettier --write .",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "deploy": "npm run build && gh-pages -d build"
+    "deploy": "npm run build && gh-pages -d build",
+    "prepare": "husky install"
   },
   "eslintConfig": {
     "extends": [
@@ -56,6 +57,14 @@
     "gh-pages": "^6.1.1",
     "eslint": "^8.57.0",
     "prettier": "^3.3.3",
-    "serve": "^14.2.0"
+    "serve": "^14.2.0",
+    "husky": "^9.0.0",
+    "lint-staged": "^15.0.0"
+  },
+  "lint-staged": {
+    "*.{js,jsx,ts,tsx,json,css,md}": [
+      "prettier --write",
+      "eslint --fix"
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- configure ESLint with a basic React setup
- add Prettier and Husky with lint-staged integration

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-plugin-react')*
- `git commit --allow-empty -m "hook test"` *(fails: 403 fetching lint-staged)*

------
https://chatgpt.com/codex/tasks/task_e_689e12575dfc832c8ae27ab7219e6cef