### PR TITLE
feat/ui-tailwind

### DIFF
--- a/my-website/package.json
+++ b/my-website/package.json
@@ -59,7 +59,10 @@
     "prettier": "^3.3.3",
     "serve": "^14.2.0",
     "husky": "^9.0.0",
-    "lint-staged": "^15.0.0"
+    "lint-staged": "^15.0.0",
+    "tailwindcss": "^3.4.4",
+    "postcss": "^8.4.27",
+    "autoprefixer": "^10.4.19"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx,json,css,md}": [

--- a/my-website/postcss.config.js
+++ b/my-website/postcss.config.js
@@ -1,0 +1,9 @@
+const plugins = [];
+try {
+  plugins.push(require('tailwindcss'));
+} catch (e) {}
+try {
+  plugins.push(require('autoprefixer'));
+} catch (e) {}
+
+module.exports = { plugins };

--- a/my-website/public/index.html
+++ b/my-website/public/index.html
@@ -34,6 +34,20 @@
 
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/pedroluiz.jpeg" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <script>
+      tailwind.config = {
+        theme: {
+          extend: {
+            colors: {
+              bg: 'var(--bg)',
+              fg: 'var(--fg)',
+              accent: 'var(--accent)',
+            },
+          },
+        },
+      };
+    </script>
+    <script src="https://cdn.tailwindcss.com"></script>
     <title>Pedro Bortot</title>
   </head>
   <body>

--- a/my-website/src/components/Card.js
+++ b/my-website/src/components/Card.js
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export default function Card({ className = '', children, ...props }) {
+  return (
+    <div
+      className={`rounded-2xl border border-white/10 shadow bg-[var(--bg)] text-[var(--fg)] ${className}`}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}

--- a/my-website/src/components/CardExample.js
+++ b/my-website/src/components/CardExample.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import Card from './Card';
+
+export default function CardExample() {
+  return (
+    <Card className="p-4">
+      <h2 className="text-lg font-bold">Card Example</h2>
+      <p className="text-sm text-[var(--fg)]/80">
+        This is a Tailwind card using custom tokens.
+      </p>
+    </Card>
+  );
+}

--- a/my-website/src/globals.css
+++ b/my-website/src/globals.css
@@ -1,3 +1,14 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  --bg: #0B0F14;
+  --fg: #E6EAF0;
+  --accent: #7C3AED;
+  color-scheme: dark;
+}
+
 body {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
@@ -5,6 +16,8 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  background-color: var(--bg);
+  color: var(--fg);
 }
 
 code {

--- a/my-website/src/index.js
+++ b/my-website/src/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import './index.css';
+import './globals.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
 import './i18n';

--- a/my-website/tailwind.config.js
+++ b/my-website/tailwind.config.js
@@ -1,0 +1,13 @@
+module.exports = {
+  content: ['./src/**/*.{js,jsx,ts,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        bg: 'var(--bg)',
+        fg: 'var(--fg)',
+        accent: 'var(--accent)',
+      },
+    },
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- add Tailwind config, dark theme tokens and global stylesheet
- include Card utility component and example
- load Tailwind via CDN in index.html

## Testing
- `npm run dev` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e1972c750832c8afa79584297b13c