### PR TITLE
feat/ui-shadcn-min

### DIFF
--- a/my-website/src/App.js
+++ b/my-website/src/App.js
@@ -7,11 +7,13 @@ import Skills from './components/Skills';
 import Experience from './components/Experience';
 import Courses from './components/Courses';
 import DownloadResume from './components/DownloadResume';
+import Playground from './components/Playground';
 import './App.css';
 
 function App() {
   return (
     <div className="App">
+      {false && <Playground />}
       <BackgroundVideo />
       <Main />
       <About />

--- a/my-website/src/components/Playground.js
+++ b/my-website/src/components/Playground.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import { Button } from './ui/button';
+import { Input } from './ui/input';
+import {
+  Dialog,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+  DialogClose,
+} from './ui/dialog';
+
+function Playground() {
+  return (
+    <div className="p-4 flex flex-col gap-4">
+      <Dialog>
+        <DialogTrigger>
+          <Button>Open Dialog</Button>
+        </DialogTrigger>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Example Dialog</DialogTitle>
+            <DialogDescription>
+              Simple demonstration of shadcn/ui components.
+            </DialogDescription>
+          </DialogHeader>
+          <Input placeholder="Type here" />
+          <DialogFooter>
+            <DialogClose>
+              <Button variant="outline">Close</Button>
+            </DialogClose>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+export default Playground;

--- a/my-website/src/components/Playground.test.js
+++ b/my-website/src/components/Playground.test.js
@@ -1,0 +1,11 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Playground from './Playground';
+
+test('renders button and opens dialog with input', async () => {
+  render(<Playground />);
+  const button = screen.getByRole('button', { name: /open dialog/i });
+  expect(button).toBeInTheDocument();
+  await userEvent.click(button);
+  expect(await screen.findByPlaceholderText(/type here/i)).toBeInTheDocument();
+});

--- a/my-website/src/components/ui/button.jsx
+++ b/my-website/src/components/ui/button.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { cn } from '../../lib/utils';
+
+const variants = {
+  default: 'bg-accent text-bg hover:bg-accent/90',
+  outline: 'border border-fg bg-bg text-fg hover:bg-fg/10',
+};
+
+const sizes = {
+  default: 'h-10 px-4 py-2',
+  sm: 'h-8 px-3',
+  lg: 'h-12 px-8',
+  icon: 'h-10 w-10',
+};
+
+export const Button = React.forwardRef(
+  ({ className = '', variant = 'default', size = 'default', ...props }, ref) => {
+    const classes = cn(
+      'inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none',
+      variants[variant],
+      sizes[size],
+      className
+    );
+    return <button ref={ref} className={classes} {...props} />;
+  }
+);
+
+Button.displayName = 'Button';

--- a/my-website/src/components/ui/dialog.jsx
+++ b/my-website/src/components/ui/dialog.jsx
@@ -1,0 +1,54 @@
+import React, { createContext, useContext, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { cn } from '../../lib/utils';
+
+const DialogContext = createContext({ open: false, setOpen: () => {} });
+
+export function Dialog({ children }) {
+  const [open, setOpen] = useState(false);
+  return <DialogContext.Provider value={{ open, setOpen }}>{children}</DialogContext.Provider>;
+}
+
+export function DialogTrigger({ children }) {
+  const { setOpen } = useContext(DialogContext);
+  return React.cloneElement(children, {
+    onClick: () => setOpen(true),
+  });
+}
+
+export function DialogContent({ className = '', children }) {
+  const { open, setOpen } = useContext(DialogContext);
+  if (!open) return null;
+  return createPortal(
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div className="absolute inset-0 bg-bg/80" onClick={() => setOpen(false)} />
+      <div className={cn('relative z-10 w-full max-w-lg rounded-md bg-bg p-6 shadow-lg', className)}>
+        {children}
+      </div>
+    </div>,
+    document.body
+  );
+}
+
+export function DialogClose({ children }) {
+  const { setOpen } = useContext(DialogContext);
+  return React.cloneElement(children, {
+    onClick: () => setOpen(false),
+  });
+}
+
+export function DialogHeader({ className = '', ...props }) {
+  return <div className={cn('flex flex-col space-y-1.5 text-center sm:text-left', className)} {...props} />;
+}
+
+export function DialogFooter({ className = '', ...props }) {
+  return <div className={cn('flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2', className)} {...props} />;
+}
+
+export function DialogTitle({ className = '', ...props }) {
+  return <h2 className={cn('text-lg font-semibold text-fg', className)} {...props} />;
+}
+
+export function DialogDescription({ className = '', ...props }) {
+  return <p className={cn('text-sm text-fg/70', className)} {...props} />;
+}

--- a/my-website/src/components/ui/input.jsx
+++ b/my-website/src/components/ui/input.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { cn } from '../../lib/utils';
+
+export const Input = React.forwardRef(({ className = '', type = 'text', ...props }, ref) => {
+  return (
+    <input
+      type={type}
+      className={cn(
+        'flex h-10 w-full rounded-md border border-fg bg-bg px-3 py-2 text-sm text-fg placeholder:text-fg/50 focus:outline-none focus:ring-2 focus:ring-accent disabled:cursor-not-allowed disabled:opacity-50',
+        className
+      )}
+      ref={ref}
+      {...props}
+    />
+  );
+});
+
+Input.displayName = 'Input';

--- a/my-website/src/lib/utils.js
+++ b/my-website/src/lib/utils.js
@@ -1,0 +1,3 @@
+export function cn(...classes) {
+  return classes.filter(Boolean).join(' ');
+}


### PR DESCRIPTION
## Summary
- add Tailwind-based Button, Input, and Dialog components
- wire up a disabled Playground to demo the new UI pieces

## Testing
- `CI=true npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e1d5c44a0832cb60db605f6bfeb0d