### PR TITLE
feat/a11y-i18n-switch

### DIFF
--- a/my-website/src/components/Main.css
+++ b/my-website/src/components/Main.css
@@ -20,13 +20,15 @@
     border: none;
     cursor: pointer;
     margin-left: 10px;
-    padding: 0;
-    overflow: hidden;
+    padding: 4px 8px;
+    display: flex;
+    align-items: center;
+    gap: 4px;
 }
 
 .flag-icon {
-    width: 60px;
-    height: 40px;
+    width: 24px;
+    height: 16px;
     display: block;
     transition: transform 0.3s ease;
     overflow: hidden;
@@ -36,6 +38,11 @@
 .flag-button:hover  {
     transform: scale(1.1);
     overflow: hidden;
+}
+
+.flag-button:focus-visible {
+    outline: 2px solid #fff;
+    outline-offset: 2px;
 }
 
 

--- a/my-website/src/components/Main.js
+++ b/my-website/src/components/Main.js
@@ -43,11 +43,25 @@ function Main() {
       <BackgroundVideo />
       <div className="main-section">
         <div className="language-selector">
-          <button onClick={() => changeLanguage('en')} className="flag-button">
-            <img src={flagEn} alt="English" className="flag-icon" />
+          <button
+            type="button"
+            onClick={() => changeLanguage('en')}
+            className="flag-button"
+            aria-pressed={i18n.language === 'en'}
+            aria-label={t('language.english')}
+          >
+            <img src={flagEn} alt="" aria-hidden="true" className="flag-icon" />
+            EN
           </button>
-          <button onClick={() => changeLanguage('ptBR')} className="flag-button">
-            <img src={flagPt} alt="Português" className="flag-icon" />
+          <button
+            type="button"
+            onClick={() => changeLanguage('ptBR')}
+            className="flag-button"
+            aria-pressed={i18n.language === 'ptBR'}
+            aria-label={t('language.portuguese')}
+          >
+            <img src={flagPt} alt="" aria-hidden="true" className="flag-icon" />
+            PT
           </button>
         </div>
         <div className="content">

--- a/my-website/src/locales/en.json
+++ b/my-website/src/locales/en.json
@@ -4,6 +4,10 @@
     "intro1": "I'm Pedro Luiz,",
     "titles": ["an Aspiring Game Designer", "a 3D Enthusiast", "an Aspiring Level Designer", "an Educator", "a Storyteller", "a Gamer", "a Streamer"]
   },
+  "language": {
+    "english": "English",
+    "portuguese": "Portuguese"
+  },
   "about": {
     "title": "About Me",
     "paragraphs": [

--- a/my-website/src/locales/ptBR.json
+++ b/my-website/src/locales/ptBR.json
@@ -4,6 +4,10 @@
       "intro1": "Eu sou Pedro Luiz,",
       "titles": ["um Aspirante a Designer de Jogos", "um Entusiasta de 3D", "um Aspirante a Designer de Níveis", "um Educador", "um Contador de Histórias", "um Jogador", "um Streamer"]
     },
+    "language": {
+      "english": "Inglês",
+      "portuguese": "Português"
+    },
     "about": {
       "title": "Sobre Mim",
       "paragraphs": [


### PR DESCRIPTION
## Summary
- replace flag-only language toggle with PT/EN buttons using aria-pressed and decorative flags
- expose language names for screen readers via react-i18next resources
- add keyboard focus styles to language selector

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts: not found)*
- `npm run lint` *(fails: Cannot find package 'eslint-plugin-react')*

------
https://chatgpt.com/codex/tasks/task_e_689e2a32976c832cb5ffce86dda28b0b