### PR TITLE
Preserve child click handlers in dialog components

### DIFF
--- a/my-website/src/components/ui/dialog.jsx
+++ b/my-website/src/components/ui/dialog.jsx
@@ -12,7 +12,10 @@ export function Dialog({ children }) {
 export function DialogTrigger({ children }) {
   const { setOpen } = useContext(DialogContext);
   return React.cloneElement(children, {
-    onClick: () => setOpen(true),
+    onClick: (e) => {
+      children.props.onClick?.(e);
+      setOpen(true);
+    },
   });
 }
 
@@ -33,7 +36,10 @@ export function DialogContent({ className = '', children }) {
 export function DialogClose({ children }) {
   const { setOpen } = useContext(DialogContext);
   return React.cloneElement(children, {
-    onClick: () => setOpen(false),
+    onClick: (e) => {
+      children.props.onClick?.(e);
+      setOpen(false);
+    },
   });
 }
 

--- a/my-website/src/components/ui/dialog.test.jsx
+++ b/my-website/src/components/ui/dialog.test.jsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Dialog, DialogTrigger, DialogContent, DialogClose } from './dialog';
+
+test('DialogTrigger preserves child onClick', async () => {
+  const handleClick = jest.fn();
+  render(
+    <Dialog>
+      <DialogTrigger>
+        <button onClick={handleClick}>Open</button>
+      </DialogTrigger>
+      <DialogContent>
+        <p>Content</p>
+      </DialogContent>
+    </Dialog>
+  );
+  const openButton = screen.getByRole('button', { name: /open/i });
+  await userEvent.click(openButton);
+  expect(handleClick).toHaveBeenCalled();
+  expect(await screen.findByText('Content')).toBeInTheDocument();
+});
+
+test('DialogClose preserves child onClick', async () => {
+  const closeClick = jest.fn();
+  render(
+    <Dialog>
+      <DialogTrigger>
+        <button>Open</button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogClose>
+          <button onClick={closeClick}>Close</button>
+        </DialogClose>
+      </DialogContent>
+    </Dialog>
+  );
+  await userEvent.click(screen.getByRole('button', { name: /open/i }));
+  const closeButton = await screen.findByRole('button', { name: /close/i });
+  await userEvent.click(closeButton);
+  expect(closeClick).toHaveBeenCalled();
+  expect(screen.queryByRole('button', { name: /close/i })).not.toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- keep existing onClick when cloning elements in `DialogTrigger` and `DialogClose`
- add tests to ensure trigger and close handlers call child onClick

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac5fbc3748832c8e4e92535ca205dd