### PR TITLE
Add IDs for projects and technologies

### DIFF
--- a/my-website/src/components/Projects.js
+++ b/my-website/src/components/Projects.js
@@ -18,6 +18,7 @@ function Projects() {
 
   const projects = [
     {
+      id: "project-0",
       title: t('projects.list.0.title'),
       description: (
         <div>
@@ -26,15 +27,16 @@ function Projects() {
       ),
       video: "https://www.youtube.com/embed/s9nfFplwr60?si=jYkn5q9rJ1f4iIMe",
       tech: [
-        { name: "Unity", icon: unityIcon },
-        { name: "C#", icon: csharpIcon },
-        { name: "3ds Max", icon: max3dsIcon },
-        { name: "Maya", icon: mayaIcon },
-        { name: "Photoshop", icon: photoshopIcon },
+        { id: "project-0-unity", name: "Unity", icon: unityIcon },
+        { id: "project-0-csharp", name: "C#", icon: csharpIcon },
+        { id: "project-0-3dsmax", name: "3ds Max", icon: max3dsIcon },
+        { id: "project-0-maya", name: "Maya", icon: mayaIcon },
+        { id: "project-0-photoshop", name: "Photoshop", icon: photoshopIcon },
       ],
       reverse: false,
     },
     {
+      id: "project-1",
       title: t('projects.list.1.title'),
       description: (
         <div>
@@ -43,17 +45,18 @@ function Projects() {
       ),
       video: "https://www.youtube.com/embed/zLuvuI2-xpw?si=RhfhEuDnlgWUT5bH",
       tech: [
-        { name: "Unity", icon: unityIcon },
-        { name: "C#", icon: csharpIcon },
-        { name: "VR SDK", icon: vrIcon },
-        { name: "3ds Max", icon: max3dsIcon },
-        { name: "Maya", icon: mayaIcon },
-        { name: "Substance Painter", icon: substancepainter },
-        { name: "Android", icon: androidIcon },
+        { id: "project-1-unity", name: "Unity", icon: unityIcon },
+        { id: "project-1-csharp", name: "C#", icon: csharpIcon },
+        { id: "project-1-vrsdk", name: "VR SDK", icon: vrIcon },
+        { id: "project-1-3dsmax", name: "3ds Max", icon: max3dsIcon },
+        { id: "project-1-maya", name: "Maya", icon: mayaIcon },
+        { id: "project-1-substance-painter", name: "Substance Painter", icon: substancepainter },
+        { id: "project-1-android", name: "Android", icon: androidIcon },
       ],
       reverse: true,
     },
     {
+      id: "project-2",
       title: t('projects.list.2.title'),
       description: (
         <div>
@@ -62,11 +65,12 @@ function Projects() {
       ),
       image: xtaon,
       tech: [
-        { name: "Substance Painter", icon: substancepainter },
+        { id: "project-2-substance-painter", name: "Substance Painter", icon: substancepainter },
       ],
       reverse: true,
     },
     {
+      id: "project-3",
       title: t('projects.list.3.title'),
       description: (
         <div>
@@ -75,9 +79,9 @@ function Projects() {
       ),
       image: litterman,
       tech: [
-        { name: "Unity", icon: unityIcon },
-        { name: "Substance Painter", icon: substancepainter },
-        { name: "Blender", icon: blenderIcon },
+        { id: "project-3-unity", name: "Unity", icon: unityIcon },
+        { id: "project-3-substance-painter", name: "Substance Painter", icon: substancepainter },
+        { id: "project-3-blender", name: "Blender", icon: blenderIcon },
       ],
       reverse: false,
     },
@@ -86,9 +90,9 @@ function Projects() {
   return (
     <section id="projects" className="projects-section">
       <h2>{t('projects.title')}</h2> {/* Título traduzido */}
-      {projects.map((project, index) => (
+      {projects.map((project) => (
         <div
-          key={index}
+          key={project.id}
           className={`project-container ${
             project.reverse ? "reverse" : ""
           }`}
@@ -115,8 +119,8 @@ function Projects() {
             <h3>{project.title}</h3>
             {project.description}
             <div className="project-tech">
-              {project.tech.map((tech, techIndex) => (
-                <div key={techIndex} className="tech-item">
+              {project.tech.map((tech) => (
+                <div key={tech.id} className="tech-item">
                   <img
                     src={tech.icon}
                     alt={`${tech.name} icon`}


### PR DESCRIPTION
## Summary
- add explicit `id` fields for all projects and technologies in Projects component
- use these ids as keys when rendering project and tech lists

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-plugin-react')*

------
https://chatgpt.com/codex/tasks/task_e_68acaf3b0360832cb20fe0f6202bc514