### PR TITLE
Use ref for About section scrolling

### DIFF
--- a/my-website/src/App.js
+++ b/my-website/src/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import Main from './components/Main';
 import About from './components/About';
@@ -12,6 +12,7 @@ import './App.css';
 
 function App() {
   const { t } = useTranslation();
+  const aboutRef = useRef(null);
 
   return (
     <div className="App">
@@ -28,8 +29,8 @@ function App() {
       </header>
       <main id="conteudo">
         {false && <Playground />}
-        <Main />
-        <About />
+        <Main aboutRef={aboutRef} />
+        <About ref={aboutRef} />
         <Skills />
         <Experience />
         <Projects />

--- a/my-website/src/components/About.js
+++ b/my-website/src/components/About.js
@@ -1,10 +1,10 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, forwardRef } from 'react';
 import ScrollReveal from 'scrollreveal';
 import './About.css';
 import { FaEnvelope, FaLinkedin, FaGithub } from 'react-icons/fa';
 import { useTranslation } from 'react-i18next';
 
-function About() {
+const About = forwardRef((props, ref) => {
   const { t } = useTranslation();
 
   useEffect(() => {
@@ -26,7 +26,7 @@ function About() {
   }, []);
 
   return (
-    <section id="about" className="about-section">
+    <section id="about" ref={ref} className="about-section">
       <div className="about-container">
         <div className="about-content">
           <h2>{t('about.title')}</h2> {/* Título traduzido */}
@@ -51,6 +51,6 @@ function About() {
       </div>
     </section>
   );
-}
+});
 
 export default About;

--- a/my-website/src/components/Main.js
+++ b/my-website/src/components/Main.js
@@ -6,8 +6,8 @@ import { useTranslation } from 'react-i18next';
 import flagEn from '../components/assets/flags/flag_en.png';
 import flagPt from '../components/assets/flags/flag_pt.png';
 
-function Main() {
-  const { t, i18n } = useTranslation(); 
+function Main({ aboutRef }) {
+  const { t, i18n } = useTranslation();
   const typedElement = useRef(null);
 
   useEffect(() => {
@@ -28,9 +28,8 @@ function Main() {
   }, [t]); 
 
   const handleScroll = () => {
-    const aboutSection = document.getElementById('about');
-    if (aboutSection) {
-      aboutSection.scrollIntoView({ behavior: 'smooth' });
+    if (aboutRef?.current) {
+      aboutRef.current.scrollIntoView({ behavior: 'smooth' });
     }
   };
 


### PR DESCRIPTION
## Summary
- create `aboutRef` in `App` and pass to `Main`
- forward About section ref and scroll via `ref.current.scrollIntoView`

## Testing
- `node - <<'NODE'\nconst handleScroll=(aboutRef)=>{if(aboutRef?.current){aboutRef.current.scrollIntoView({behavior:'smooth'});}}\nconst aboutRef={current:{scrollIntoView:(opts)=>console.log('scrollIntoView called',opts)}};\nhandleScroll(aboutRef);\nNODE`
- `npm run lint` *(fails: Cannot find package 'eslint-plugin-react')*


------
https://chatgpt.com/codex/tasks/task_e_68acafedd774832c815b6b6c7edea4d5