### PR TITLE
refactor: replace require with asset imports

### DIFF
--- a/my-website/src/components/About.js
+++ b/my-website/src/components/About.js
@@ -3,6 +3,7 @@ import ScrollReveal from 'scrollreveal';
 import './About.css';
 import { FaEnvelope, FaLinkedin, FaGithub } from 'react-icons/fa';
 import { useTranslation } from 'react-i18next';
+import pedroluiz from './assets/pedroluiz.jpeg';
 
 const About = forwardRef((props, ref) => {
   const { t } = useTranslation();
@@ -46,7 +47,7 @@ const About = forwardRef((props, ref) => {
           </div>
         </div>
         <div className="about-image">
-          <img src={require('./assets/pedroluiz.jpeg')} alt="Pedro Luiz" />
+          <img src={pedroluiz} alt="Pedro Luiz" />
         </div>
       </div>
     </section>

--- a/my-website/src/components/BackgroundVideo.js
+++ b/my-website/src/components/BackgroundVideo.js
@@ -1,11 +1,12 @@
 import React from 'react';
 import './BackgroundVideo.css';
+import bgVideo from './assets/BG.mp4';
 
 function BackgroundVideo() {
   return (
     <div className="background-video">
       <video autoPlay muted loop playsInline>
-      <source src={require('./assets/BG.mp4')} type="video/mp4" />
+        <source src={bgVideo} type="video/mp4" />
       </video>
       <div className="overlay"></div>
     </div>

--- a/my-website/src/components/Main.js
+++ b/my-website/src/components/Main.js
@@ -2,9 +2,10 @@ import React, { useEffect, useRef } from 'react';
 import Typed from 'typed.js';
 import './Main.css';
 import BackgroundVideo from './BackgroundVideo';
-import { useTranslation } from 'react-i18next'; 
+import { useTranslation } from 'react-i18next';
 import flagEn from '../components/assets/flags/flag_en.png';
 import flagPt from '../components/assets/flags/flag_pt.png';
+import arrow from '../components/assets/tech-icons/arrow.svg';
 
 function Main({ aboutRef }) {
   const { t, i18n } = useTranslation();
@@ -73,7 +74,7 @@ function Main({ aboutRef }) {
           </h2>
         </div>
         <div className="scroll-down-indicator" onClick={handleScroll}>
-          <img src={require('../components/assets/tech-icons/arrow.svg').default} alt="Scroll Down" className="arrow" />
+          <img src={arrow} alt="Scroll Down" className="arrow" />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- use ES module imports for static assets in About, BackgroundVideo, and Main components

## Testing
- `npm ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/husky)*
- `npm run build` *(fails: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acb172591c832c8c21c955d9f150c9