### PR TITLE
chore: rebuild pages deploy to work without npm ci

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -28,11 +28,15 @@ jobs:
           cache: npm
           cache-dependency-path: my-website/package-lock.json
 
-      - name: Force npm registry
-        run: npm config set registry https://registry.npmjs.org/
+      - name: Reset npm config and force registry
+        run: |
+          rm -f ~/.npmrc
+          rm -f my-website/.npmrc
+          rm -f .npmrc
+          npm config set registry https://registry.npmjs.org/
 
       - name: Install dependencies
-        run: npm ci --no-audit --no-fund --ignore-scripts
+        run: npm install --no-audit --no-fund --ignore-scripts
         working-directory: my-website
         env:
           NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
@@ -40,6 +44,8 @@ jobs:
       - name: Build
         run: npm run build
         working-directory: my-website
+        env:
+          NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
 
       - name: Configure Pages
         uses: actions/configure-pages@v5


### PR DESCRIPTION
### Motivation
- Fix GitHub Actions Pages deploy failures caused by lockfile/`npm ci` issues and 403s from runner npm configuration by running installs inside `my-website/` and forcing the public registry.
- Make the Pages pipeline fully functional from Actions without relying on a local environment or `npm ci`.

### Description
- Update `.github/workflows/deploy-gh-pages.yml` to add a pre-install step that removes `~/.npmrc`, `my-website/.npmrc`, and `./.npmrc` and runs `npm config set registry https://registry.npmjs.org/`.
- Replace `npm ci` with `npm install --no-audit --no-fund --ignore-scripts` and set `working-directory: my-website` and `env: NPM_CONFIG_REGISTRY=https://registry.npmjs.org/` for install.
- Ensure the `npm run build` step runs in `my-website` with the registry env and keep the artifact upload path as `my-website/build`.
- Preserve the workflow trigger on push to `main` and Pages permissions so the job runs on `main` pushes.

### Testing
- No automated tests were run; this is a workflow-only change and should be validated by letting the Actions workflow run on a push to `main`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969345d8eb4832ca7e454b0a5df172b)