### PR TITLE
fix: resolve Inter font path for CRA build

### DIFF
--- a/my-website/public/index.html
+++ b/my-website/public/index.html
@@ -22,6 +22,15 @@
       type="font/woff2"
       crossorigin
     />
+    <style>
+      @font-face {
+        font-family: 'Inter';
+        font-style: normal;
+        font-weight: 100 900;
+        font-display: swap;
+        src: url("/fonts/Inter-roman.var.woff2") format("woff2");
+      }
+    </style>
 
     <!-- Descrição do site -->
     <meta name="description" content="Portfólio de Pedro Luiz Bortot Monteiro do Rosário - Desenvolvedor de Jogos e Designer." />

--- a/my-website/src/globals.css
+++ b/my-website/src/globals.css
@@ -2,14 +2,6 @@
 @tailwind components;
 @tailwind utilities;
 
-@font-face {
-  font-family: 'Inter';
-  font-style: normal;
-  font-weight: 100 900;
-  font-display: swap;
-  src: url('/fonts/Inter-roman.var.woff2') format('woff2');
-}
-
 :root {
   --bg: #0B0F14;
   --fg: #E6EAF0;


### PR DESCRIPTION
### Motivation
- Fix CRA build failure caused by resolving `'/fonts/Inter-roman.var.woff2'` from `src` by ensuring the font is served from the public folder so the bundler doesn't try to import it as a module.
- Preserve site layout and font usage while preventing the build-time resolution error.

### Description
- Removed the `@font-face` rule from `my-website/src/globals.css` so CRA no longer attempts to resolve the font from `src`.
- Added an inline `@font-face` declaration to `my-website/public/index.html` that references the font as `src: url("/fonts/Inter-roman.var.woff2")` and kept the existing preload link to `"%PUBLIC_URL%/fonts/Inter-roman.var.woff2"`.
- Kept the `font-family` usage and fallback stack in `globals.css` unchanged to avoid layout or typography regressions.

### Testing
- Ran `npm run build` in the workspace, which failed in this environment because `react-scripts` was not found, so a full build could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69693540c0e0832c96f0d3367102b9f5)