### PR TITLE
Add NozzleNote by BMR to the highlights section

### DIFF
--- a/my-website/src/locales/en.json
+++ b/my-website/src/locales/en.json
@@ -62,6 +62,25 @@
     },
     "items": [
       {
+        "title": "NozzleNote by BMR",
+        "objective": "A local-first desktop app for tracking 3D printers: maintenance, history, parts, inventory, and backups. Currently preparing for Open Beta.",
+        "scope": [
+          "Guided onboarding (8 screens) and an in-app tutorial for core workflows",
+          "100% local storage in SQLite — no account, cloud, or telemetry",
+          "JSON backup/export, with bilingual support (EN/PT-BR)"
+        ],
+        "tools": ["Tauri", "Rust", "SQLite", "GitHub Actions"],
+        "evidence": [
+          { "label": "nozzlenote.com", "path": "https://nozzlenote.com" },
+          { "label": "Private repository (bmr-printcare)" }
+        ],
+        "learnings": [
+          "Built a desktop release process with strict version control (semver tag vs. the Windows installer's numeric version).",
+          "Set up a QA pipeline with a checklist and manual validation before every public build.",
+          "Kept careful compatibility with legacy data (the project's earlier internal name) without breaking existing backups."
+        ]
+      },
+      {
         "title": "Testing this very portfolio",
         "objective": "Validate usability, content consistency, and correct behavior across key sections.",
         "scope": [

--- a/my-website/src/locales/ptBR.json
+++ b/my-website/src/locales/ptBR.json
@@ -62,6 +62,25 @@
     },
     "items": [
       {
+        "title": "NozzleNote by BMR",
+        "objective": "App desktop local-first para gerenciar impressoras 3D: manutenções, histórico, peças, estoque e backups. Atualmente em preparação para Open Beta.",
+        "scope": [
+          "Onboarding guiado (8 telas) e tutorial in-app para os fluxos principais",
+          "Armazenamento 100% local em SQLite — sem conta, nuvem ou telemetria",
+          "Backup e exportação em JSON, com suporte bilíngue (PT-BR/EN)"
+        ],
+        "tools": ["Tauri", "Rust", "SQLite", "GitHub Actions"],
+        "evidence": [
+          { "label": "nozzlenote.com", "path": "https://nozzlenote.com" },
+          { "label": "Repositório privado (bmr-printcare)" }
+        ],
+        "learnings": [
+          "Estruturei um processo de release para desktop com controle rigoroso de versão (tag semver vs. versão numérica do instalador Windows).",
+          "Criei um pipeline de QA com checklist e validação manual antes de cada build pública.",
+          "Mantive compatibilidade com dados legados (nome interno anterior do projeto) sem quebrar backups existentes."
+        ]
+      },
+      {
         "title": "Testes deste próprio portfólio",
         "objective": "Validar usabilidade, consistência de conteúdo e funcionamento das seções principais.",
         "scope": [


### PR DESCRIPTION
## Summary

Adds NozzleNote by BMR as the lead card in the Highlights section (both EN and PT-BR). It's a real personal project — a local-first desktop app (Tauri/Rust, SQLite) for tracking 3D printers, maintenance, parts, inventory, and backups, currently preparing for Open Beta — and it ties Pedro's hands-on 3D-printing background to actual software engineering (release process, QA discipline, i18n, data-safety practices).

- `src/locales/en.json` / `src/locales/ptBR.json`: new first entry in `projects.items` with scope, tools (Tauri, Rust, SQLite, GitHub Actions), evidence (links to `nozzlenote.com`; the private repo is listed as plain text, not linked), and learnings drawn from the project's release/QA process.

## Test plan

- [x] Validated both JSON files parse correctly
- [x] `npm run lint`
- [x] `npm run build`
- [x] Verified the new card renders correctly in a real browser (screenshot)


---
_Generated by [Claude Code](https://claude.ai/code/session_01BGpZFStfiYe9N1mMhvkQAk)_